### PR TITLE
change flush_count from uint16 to uint32

### DIFF
--- a/electrumx/server/db.py
+++ b/electrumx/server/db.py
@@ -721,14 +721,14 @@ class DB:
 
         last = time.monotonic()
         count = 0
-        for cursor in range(65536):
-            prefix = b'u' + pack_be_uint16(cursor)
+        for cursor in range(4294967296):
+            prefix = b'u' + pack_be_uint32(cursor)
             count += upgrade_u_prefix(prefix)
             now = time.monotonic()
             if now > last + 10:
                 last = now
                 self.logger.info(f'DB 1 of 3: {count:,d} entries updated, '
-                                 f'{cursor * 100 / 65536:.1f}% complete')
+                                 f'{cursor * 100 / 4294967296:.1f}% complete')
         self.logger.info('DB 1 of 3 upgraded successfully')
 
         def upgrade_h_prefix(prefix):
@@ -755,14 +755,14 @@ class DB:
 
         last = time.monotonic()
         count = 0
-        for cursor in range(65536):
-            prefix = b'h' + pack_be_uint16(cursor)
+        for cursor in range(4294967296):
+            prefix = b'h' + pack_be_uint32(cursor)
             count += upgrade_h_prefix(prefix)
             now = time.monotonic()
             if now > last + 10:
                 last = now
                 self.logger.info(f'DB 2 of 3: {count:,d} entries updated, '
-                                 f'{cursor * 100 / 65536:.1f}% complete')
+                                 f'{cursor * 100 / 4294967296:.1f}% complete')
 
         # Upgrade tx_counts file
         size = (self.db_height + 1) * 8

--- a/tests/server/test_compaction.py
+++ b/tests/server/test_compaction.py
@@ -6,7 +6,7 @@ from os import environ, urandom
 import pytest
 
 from electrumx.lib.hash import HASHX_LEN
-from electrumx.lib.util import pack_be_uint16, pack_le_uint64
+from electrumx.lib.util import pack_be_uint16, pack_be_uint32, pack_le_uint64
 from electrumx.server.env import Env
 from electrumx.server.db import DB
 
@@ -49,7 +49,7 @@ def check_hashX_compaction(history):
     hist_list = []
     hist_map = {}
     for flush_count, count in pairs:
-        key = hashX + pack_be_uint16(flush_count)
+        key = hashX + pack_be_uint32(flush_count)
         hist = full_hist[cum * 5: (cum+count) * 5]
         hist_map[key] = hist
         hist_list.append(hist)


### PR DESCRIPTION
<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the Travis tests pass. -->